### PR TITLE
release: bump SDK to 2.4.9 with ctypes and stream message fixes

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -82,6 +82,13 @@ conclusion: the diff is not stable, but seems to less than 200ms.
 
 # 更新日志
 
+## 2026.06.24 Release Version 2.4.9
+
+- **修复**:
+  - 修复send_stream_message的bug
+  - 修复不完全标准的ctytpes.POINTER的bug
+
+
 ## 2026.06.24 Release Version 2.4.8
 
 - **修复**:

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ python agora_rtc/examples/example_audio_pcm_send.py --appId=xxx --channelId=xxx 
 
 # Change log
 
+## 2026.06.24 Release Version 2.4.9
+
+- **Bugfixes**:
+  - Fixed a bug in `send_stream_message`.
+  - Fixed a bug with the non-standard usage of `ctypes.POINTER`.
+
 ## 2026.06.24 Release Version 2.4.8
 
 - **Bugfixes**:

--- a/agora_rtc/README.cn.md
+++ b/agora_rtc/README.cn.md
@@ -82,6 +82,12 @@ conclusion: the diff is not stable, but seems to less than 200ms.
 
 # 更新日志
 
+## 2026.06.24 Release Version 2.4.9
+
+- **修复**:
+  - 修复send_stream_message的bug
+  - 修复不完全标准的ctytpes.POINTER的bug
+
 ## 2026.06.24 Release Version 2.4.8
 
 - **修复**:

--- a/agora_rtc/README.md
+++ b/agora_rtc/README.md
@@ -50,6 +50,12 @@ python agora_rtc/examples/example_audio_pcm_send.py --appId=xxx --channelId=xxx 
 
 # Release Note
 
+## 2026.06.24 Release Version 2.4.9
+
+- **Bugfixes**:
+  - Fixed a bug in `send_stream_message`.
+  - Fixed a bug with the non-standard usage of `ctypes.POINTER`.
+
 ## 2026.06.24 Release Version 2.4.8
 
 - **Bugfixes**:

--- a/agora_rtc/agora/rtc/audio_encoded_frame_sender.py
+++ b/agora_rtc/agora/rtc/audio_encoded_frame_sender.py
@@ -24,7 +24,7 @@ class AudioEncodedFrameSender:
     #     return ret
 
     def send_encoded_audio_frame(self, buffer_ptr: int, buffer_size: int, frame_info: EncodedAudioFrameInfo):
-        buffer_ptr = ctypes.cast(buffer_ptr, ctypes.POINTER(ctypes.c_void_p))
+        buffer_ptr = ctypes.cast(buffer_ptr, ctypes.c_void_p)
         ret = agora_audio_encoded_frame_sender_send(self.sender_handle, buffer_ptr, ctypes.c_uint32(buffer_size), ctypes.byref(EncodedAudioFrameInfoInner.create(frame_info)))
         return ret
     def send_encoded_audio_frame_withbytes(self, data, frame_info: EncodedAudioFrameInfo):
@@ -32,10 +32,10 @@ class AudioEncodedFrameSender:
        
             # 将 bytearray 转换为 c_char_p 而不拷贝内存
         if isinstance(data, bytearray):
-            c_data = ctypes.cast(data, ctypes.POINTER(ctypes.c_void_p))
+            c_data = ctypes.cast(data, ctypes.c_void_p)
         else:
             # 如果已经是 bytes，直接转换
-            c_data = ctypes.cast(data, ctypes.POINTER(ctypes.c_void_p))
+            c_data = ctypes.cast(data, ctypes.c_void_p)
         
         ret = agora_audio_encoded_frame_sender_send(self.sender_handle, c_data, ctypes.c_uint32(buffer_size), ctypes.byref(EncodedAudioFrameInfoInner.create(frame_info)))
         return ret

--- a/agora_rtc/agora/rtc/audio_pcm_data_sender.py
+++ b/agora_rtc/agora/rtc/audio_pcm_data_sender.py
@@ -18,7 +18,7 @@ class AudioPcmDataSender:
 
     def send_audio_pcm_data(self, frame: PcmAudioFrame):
         c_data = (ctypes.c_char * len(frame.data)).from_buffer(frame.data)
-        c_data_ptr = ctypes.cast(c_data, ctypes.POINTER(ctypes.c_void_p))
+        c_data_ptr = ctypes.cast(c_data, ctypes.c_void_p)
         # c_data_ptr = ctypes.cast(frame.data, ctypes.c_char_p)
         pts = ctypes.c_int64(frame.present_time_ms)
         ret = agora_audio_pcm_data_sender_send(self.sender_handle, c_data_ptr, frame.timestamp, pts,frame.samples_per_channel, frame.bytes_per_sample, frame.number_of_channels, frame.sample_rate)

--- a/agora_rtc/agora/rtc/rtc_connection.py
+++ b/agora_rtc/agora/rtc/rtc_connection.py
@@ -211,11 +211,20 @@ class RTCConnection:
         return ret
     
     # send data stream message to connection
+    # data can be str or bytes/bytearray object,is diff to send_sream_message which is a str object
     def send_stream_message(self, data) -> int:
+        if data is None:
+            return -1001
         length = len(data)
-        #c_data = ctypes.c_char_p(data)
-        arr = (ctypes.c_char * length).from_buffer(data)   # zero copy
-        ptr = ctypes.cast(arr, ctypes.POINTER(ctypes.c_char_p))
+        if length == 0:
+            return 0
+        if isinstance(data, str):
+            data = data.encode('utf-8')
+        elif isinstance(data, (bytes, bytearray)):
+            data = bytes(data)
+        else:
+            return -1002
+        ptr = ctypes.c_char_p(data)
         ret = agora_rtc_conn_send_stream_message(
             self.conn_handle,
             self._data_stream_id,

--- a/agora_rtc/examples/example_api_test.py
+++ b/agora_rtc/examples/example_api_test.py
@@ -708,8 +708,16 @@ def main():
                 connection.push_audio_pcm_data(audio_buffer, sample_rate, channels)
                 print("push audio pcm data")
         time.sleep(0.05)
-        #connection.send_stream_message("stream test")
-        #connection.send_audio_meta_data("audio meta data test")
+        ret = connection.send_stream_message(b"stream test")
+        print(f"send stream message ret = {ret}")
+        ret = connection.send_stream_message("stream test")
+        print(f"send stream message ret = {ret}")
+        ret = connection.send_stream_message(bytearray(b"stream test"))
+        print(f"send stream message ret = {ret}")
+        ret = connection.send_stream_message("")
+        print(f"send stream message ret = {ret}")
+        ret = connection.send_audio_meta_data("audio meta data test")
+        print(f"send audio meta data ret = {ret}")
 
      # release resource
     print("release resource now")

--- a/agora_rtc/examples/example_audio_vad.py
+++ b/agora_rtc/examples/example_audio_vad.py
@@ -226,6 +226,16 @@ def main():
             if ret == True:
                connection.push_audio_pcm_data(slice_data, 16000, 1)
             time.sleep(0.05)
+            ret = connection.send_stream_message(b"stream test")
+            print(f"send stream message ret = {ret}")
+            ret = connection.send_stream_message("stream test")
+            print(f"send stream message ret = {ret}")
+            ret = connection.send_stream_message(bytearray(b"stream test"))
+            print(f"send stream message ret = {ret}")
+            ret = connection.send_stream_message("")
+            print(f"send stream message ret = {ret}")
+            ret = connection.send_audio_meta_data("audio meta data test")
+            print(f"send audio meta data ret = {ret}")
 
 
      # release resource

--- a/agora_rtc/setup.py
+++ b/agora_rtc/setup.py
@@ -134,7 +134,7 @@ class CustomInstallCommand(install):
 
 setup(
     name='agora_python_server_sdk',
-    version='2.4.8',
+    version='2.4.9',
     description='A Python SDK for Agora Server',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Fix non-standard ctypes pointer casting for audio senders and accept str/bytes/bytearray in send_stream_message.